### PR TITLE
Add `_` to identifier names

### DIFF
--- a/lib/factory-name.js
+++ b/lib/factory-name.js
@@ -6,6 +6,8 @@ var asciiAlpha = require('micromark/dist/character/ascii-alpha')
 var asciiAlphanumeric = require('micromark/dist/character/ascii-alphanumeric')
 
 function createName(effects, ok, nok, nameType) {
+  var self = this
+
   return start
 
   function start(code) {
@@ -19,12 +21,17 @@ function createName(effects, ok, nok, nameType) {
   }
 
   function name(code) {
-    if (code === 45 /* `-` */ || asciiAlphanumeric(code)) {
+    if (
+      code === 45 /* `-` */ ||
+      code === 95 /* `_` */ ||
+      asciiAlphanumeric(code)
+    ) {
       effects.consume(code)
       return name
     }
 
     effects.exit(nameType)
-    return ok(code)
+    // To do next major: disallow `-` at end of name too, for consistency.
+    return self.previous === 95 /* `_` */ ? nok(code) : ok(code)
   }
 }

--- a/lib/tokenize-directive-container.js
+++ b/lib/tokenize-directive-container.js
@@ -42,7 +42,13 @@ function tokenizeDirectiveContainer(effects, ok, nok) {
     }
 
     effects.exit('directiveContainerSequence')
-    return createName(effects, afterName, nok, 'directiveContainerName')(code)
+    return createName.call(
+      self,
+      effects,
+      afterName,
+      nok,
+      'directiveContainerName'
+    )(code)
   }
 
   function afterName(code) {

--- a/lib/tokenize-directive-leaf.js
+++ b/lib/tokenize-directive-leaf.js
@@ -12,6 +12,8 @@ var label = {tokenize: tokenizeLabel, partial: true}
 var attributes = {tokenize: tokenizeAttributes, partial: true}
 
 function tokenizeDirectiveLeaf(effects, ok, nok) {
+  var self = this
+
   return start
 
   function start(code) {
@@ -28,7 +30,7 @@ function tokenizeDirectiveLeaf(effects, ok, nok) {
     if (code === 58 /* `:` */) {
       effects.consume(code)
       effects.exit('directiveLeafSequence')
-      return createName(effects, afterName, nok, 'directiveLeafName')
+      return createName.call(self, effects, afterName, nok, 'directiveLeafName')
     }
 
     return nok(code)

--- a/lib/tokenize-directive-text.js
+++ b/lib/tokenize-directive-text.js
@@ -36,7 +36,7 @@ function tokenizeDirectiveText(effects, ok, nok) {
     effects.enter('directiveTextMarker')
     effects.consume(code)
     effects.exit('directiveTextMarker')
-    return createName(effects, afterName, nok, 'directiveTextName')
+    return createName.call(self, effects, afterName, nok, 'directiveTextName')
   }
 
   function afterName(code) {

--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,8 @@ He dies.
 :::
 
 The `name` part is required.  The first character must be a letter, other
-characters can be alphanumerical and `-`.
+characters can be alphanumerical, `-`, and `_`.
+`_` cannot end a name.
 
 The `[label]` part is optional (`:x` and `:x[]` are equivalent)†.
 When used, it can include text constructs such as emphasis and so on: `x[a *b*

--- a/test.js
+++ b/test.js
@@ -49,6 +49,12 @@ test('micromark-extension-directive (syntax)', function (t) {
     )
 
     t.equal(
+      micromark(':_', options()),
+      '<p>:_</p>',
+      'should not support a colon followed by an underscore'
+    )
+
+    t.equal(
       micromark(':a9', options()),
       '<p></p>',
       'should support a digit in a name'
@@ -61,9 +67,45 @@ test('micromark-extension-directive (syntax)', function (t) {
     )
 
     t.equal(
+      micromark(':a_b', options()),
+      '<p></p>',
+      'should support an underscore in a name'
+    )
+
+    t.equal(
+      micromark(':a_', options()),
+      '<p>:a_</p>',
+      'should *not* support an underscore at the end of a name'
+    )
+
+    t.equal(
       micromark(':a:', options()),
       '<p>:a:</p>',
       'should *not* support a colon right after a name'
+    )
+
+    t.equal(
+      micromark(':+1:', options()),
+      '<p>:+1:</p>',
+      'should not interfere w/ gemoji (1)'
+    )
+
+    t.equal(
+      micromark(':heart:', options()),
+      '<p>:heart:</p>',
+      'should not interfere w/ gemoji (2)'
+    )
+
+    t.equal(
+      micromark(':call_me_hand:', options()),
+      '<p>:call_me_hand:</p>',
+      'should not interfere w/ gemoji (3)'
+    )
+
+    t.equal(
+      micromark('_:directive_', options()),
+      '<p><em>:directive</em></p>',
+      'should not interfere w/ emphasis (`_`)'
     )
 
     t.equal(


### PR DESCRIPTION
*   Add support for underscore in names to prevent interference w/ gemoji
*   Disallow underscore at end of name to prevent interference w/ emphasis

Related to remarkjs/remark#651.

/cc @baumandm, @farnabaz