### PR TITLE
fix extra colon mark in test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1372,7 +1372,7 @@ test('content', (t) => {
   )
 
   t.equal(
-    micromark('::::div{.big}\n:::div{.small}\nText', options({'*': h})),
+    micromark(':::div{.big}\n:::div{.small}\nText', options({'*': h})),
     '<div class="big">\n<div class="small">\n<p>Text</p>\n</div>\n</div>',
     'should support container directives in container directives'
   )


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Removed one extra colon sign in test. I guess this is not a feature but a typo, if otherwise feel free to close it.

<!--do not edit: pr-->
