### PR TITLE
Adds support for colons in directive names

### DIFF
--- a/dev/lib/factory-name.js
+++ b/dev/lib/factory-name.js
@@ -35,6 +35,7 @@ export function factoryName(effects, ok, nok, type) {
     if (
       code === codes.dash ||
       code === codes.underscore ||
+      code === codes.colon ||
       asciiAlphanumeric(code)
     ) {
       effects.consume(code)
@@ -42,7 +43,9 @@ export function factoryName(effects, ok, nok, type) {
     }
 
     effects.exit(type)
-    return self.previous === codes.dash || self.previous === codes.underscore
+    return self.previous === codes.dash ||
+      self.previous === codes.underscore ||
+      self.previous === codes.colon
       ? nok(code)
       : ok(code)
   }

--- a/test/index.js
+++ b/test/index.js
@@ -735,6 +735,12 @@ test('micromark-extension-directive (syntax, leaf)', () => {
     '<blockquote>\n<p>a</p>\n</blockquote>\n<b></b>',
     'should not support lazyness (2)'
   )
+
+  assert.equal(
+    micromark('::a:b{c=d}', options()),
+    '',
+    'should support a colon in a directive name'
+  )
 })
 
 test('micromark-extension-directive (syntax, container)', () => {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [X] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [X] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [X] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [X] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [X] If applicable, I’ve added docs and tests

### Description of changes

This PR adds support for colons within a leaf directory name. This syntax is helpful to create namespaced methods, like so: `::hello:alice` and `::hello:bob`.

I needed this for a particular use case and wasn't planning on submitting a PR to the original repo. In honesty, it probably shouldn't be merged since it isn't according to the common spec. Still, I'm submitting it here for transparency and interesting conversations.

<!--do not edit: pr-->
