### PR TITLE
Enable wide Unicode support for names

### DIFF
--- a/dev/lib/factory-name.js
+++ b/dev/lib/factory-name.js
@@ -18,8 +18,6 @@ import {codes, constants} from 'micromark-util-symbol'
  * @param {TokenType} type
  */
 export function factoryName(effects, ok, nok, type) {
-  const self = this
-
   return start
 
   /** @type {State} */
@@ -41,7 +39,7 @@ export function factoryName(effects, ok, nok, type) {
     }
 
     effects.exit(type)
-    return allowedEdgeCharacter(self.previous) ? ok(code) : nok(code)
+    return ok(code)
   }
 }
 

--- a/dev/lib/factory-name.js
+++ b/dev/lib/factory-name.js
@@ -18,6 +18,8 @@ import {codes, constants} from 'micromark-util-symbol'
  * @param {TokenType} type
  */
 export function factoryName(effects, ok, nok, type) {
+  const self = this
+
   return start
 
   /** @type {State} */
@@ -39,7 +41,7 @@ export function factoryName(effects, ok, nok, type) {
     }
 
     effects.exit(type)
-    return ok(code)
+    return allowedEdgeCharacter(self.previous) ? ok(code) : nok(code)
   }
 }
 

--- a/dev/lib/factory-name.js
+++ b/dev/lib/factory-name.js
@@ -10,21 +10,6 @@ import {asciiAlphanumeric} from 'micromark-util-character'
 import {classifyCharacter} from 'micromark-util-classify-character'
 import {codes, constants} from 'micromark-util-symbol'
 
-/** @param {Code} code **/
-const allowedCharacter = (code) =>
-  code !== null && code <= codes.del
-    ? code === codes.dash ||
-      code === codes.dot ||
-      code === codes.underscore ||
-      asciiAlphanumeric(code)
-    : classifyCharacter(code) !== constants.characterGroupWhitespace
-
-/** @param {Code} code **/
-const allowedEdgeCharacter = (code) =>
-  allowedCharacter(code) &&
-  classifyCharacter(code) !== constants.characterGroupPunctuation &&
-  code !== codes.underscore
-
 /**
  * @this {TokenizeContext}
  * @param {Effects} effects
@@ -58,4 +43,31 @@ export function factoryName(effects, ok, nok, type) {
     effects.exit(type)
     return allowedEdgeCharacter(self.previous) ? ok(code) : nok(code)
   }
+}
+
+/**
+ * Checks if the character code is valid for a directive name
+ *
+ * @param {Code} code
+ **/
+function allowedCharacter(code) {
+  return code !== null && code <= codes.del
+    ? code === codes.dash ||
+        code === codes.dot ||
+        code === codes.underscore ||
+        asciiAlphanumeric(code)
+    : classifyCharacter(code) !== constants.characterGroupWhitespace
+}
+
+/**
+ * Checks if the character code is valid as a directive name start (or end)
+ *
+ * @param {Code} code
+ **/
+function allowedEdgeCharacter(code) {
+  return (
+    allowedCharacter(code) &&
+    classifyCharacter(code) !== constants.characterGroupPunctuation &&
+    code !== codes.underscore
+  )
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "micromark-factory-space": "^2.0.0",
     "micromark-factory-whitespace": "^2.0.0",
     "micromark-util-character": "^2.0.0",
+    "micromark-util-classify-character": "^2.0.0",
     "micromark-util-symbol": "^2.0.0",
     "micromark-util-types": "^2.0.0",
     "parse-entities": "^4.0.0"

--- a/test/index.js
+++ b/test/index.js
@@ -81,6 +81,16 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
     assert.equal(micromark(':xγз', options()), '<p></p>')
   })
 
+  await t.test('should support unicode accents inner name', async function () {
+    // (Decomposed) Combining Acute Accent in Cyrillic
+    assert.equal(micromark(':за́мок-чи-замо́к', options()), '<p></p>')
+  })
+
+  await t.test('should support unicode accents at the name end', async function () {
+    // (Decomposed) Combining Circumflex Accent in Latin
+    assert.equal(micromark(':â', options()), '<p></p>')
+  })
+
   await t.test(
     'should *not* support punctuation at the end of a name',
     async function () {
@@ -429,6 +439,16 @@ test('micromark-extension-directive (syntax, leaf)', async function (t) {
   await t.test('should support unicode alphabets in name', async function () {
     // Latin, Greek, Cyrillic respectively
     assert.equal(micromark('::xγз', options()), '')
+  })
+
+  await t.test('should support unicode accents inner name', async function () {
+    // (Decomposed) Combining Acute Accent in Cyrillic
+    assert.equal(micromark('::за́мок-чи-замо́к', options()), '')
+  })
+
+  await t.test('should support unicode accents at the name end', async function () {
+    // (Decomposed) Combining Circumflex Accent in Latin
+    assert.equal(micromark('::â', options()), '')
   })
 
   await t.test(
@@ -802,6 +822,16 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
   await t.test('should support unicode alphabets in name', async function () {
     // Latin, Greek, Cyrillic respectively
     assert.equal(micromark(':::xγз', options()), '')
+  })
+
+  await t.test('should support unicode accents inner name', async function () {
+    // (Decomposed) Combining Acute Accent in Cyrillic
+    assert.equal(micromark(':::за́мок-чи-замо́к', options()), '')
+  })
+
+  await t.test('should support unicode accents at the name end', async function () {
+    // (Decomposed) Combining Circumflex Accent in Latin
+    assert.equal(micromark(':::â', options()), '')
   })
 
   await t.test(

--- a/test/index.js
+++ b/test/index.js
@@ -64,7 +64,7 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
       assert.equal(micromark(':-', options()), '<p>:-</p>')
       assert.equal(micromark(':_', options()), '<p>:_</p>')
       assert.equal(micromark(':.', options()), '<p>:.</p>')
-      assert.equal(micromark(':\u2014', options()), '<p>:\u2014</p>') // Em dash
+      assert.equal(micromark(':—', options()), '<p>:—</p>') // em dash
     }
   )
 
@@ -97,7 +97,7 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
       assert.equal(micromark(':a-', options()), '<p>:a-</p>')
       assert.equal(micromark(':a_', options()), '<p>:a_</p>')
       assert.equal(micromark(':a.', options()), '<p>:a.</p>')
-      assert.equal(micromark(':a\u2014', options()), '<p>:a\u2014</p>') // Em dash
+      assert.equal(micromark(':a—', options()), '<p>:a—</p>') // em dash
     }
   )
 
@@ -420,7 +420,7 @@ test('micromark-extension-directive (syntax, leaf)', async function (t) {
       assert.equal(micromark('::-', options()), '<p>::-</p>')
       assert.equal(micromark('::_', options()), '<p>::_</p>')
       assert.equal(micromark('::.', options()), '<p>::.</p>')
-      assert.equal(micromark('::\u2014', options()), '<p>::\u2014</p>') // Em dash
+      assert.equal(micromark('::—', options()), '<p>::—</p>') // em dash
     }
   )
 
@@ -433,7 +433,7 @@ test('micromark-extension-directive (syntax, leaf)', async function (t) {
     assert.equal(micromark('::a-b', options()), '')
     assert.equal(micromark('::a_b', options()), '')
     assert.equal(micromark('::a.b', options()), '')
-    assert.equal(micromark('::a\u2014b', options()), '')
+    assert.equal(micromark('::a—b', options()), '')
   })
 
   await t.test('should support unicode alphabets in name', async function () {
@@ -804,7 +804,7 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
       assert.equal(micromark(':::-', options()), '<p>:::-</p>')
       assert.equal(micromark(':::_', options()), '<p>:::_</p>')
       assert.equal(micromark(':::.', options()), '<p>:::.</p>')
-      assert.equal(micromark(':::\u2014', options()), '<p>:::\u2014</p>') // Em dash
+      assert.equal(micromark(':::—', options()), '<p>:::—</p>') // em dash
     }
   )
 
@@ -816,7 +816,7 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
     assert.equal(micromark(':::a-b', options()), '')
     assert.equal(micromark(':::a_b', options()), '')
     assert.equal(micromark(':::a.b', options()), '')
-    assert.equal(micromark(':::a\u2014b', options()), '') // Em dash
+    assert.equal(micromark(':::a—b', options()), '') // em dash
   })
 
   await t.test('should support unicode alphabets in name', async function () {

--- a/test/index.js
+++ b/test/index.js
@@ -43,12 +43,9 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
     }
   )
 
-  await t.test(
-    'should not support a colon not followed by an alpha',
-    async function () {
-      assert.equal(micromark(':', options()), '<p>:</p>')
-    }
-  )
+  await t.test('should not support a lonely colon', async function () {
+    assert.equal(micromark(':', options()), '<p>:</p>')
+  })
 
   await t.test(
     'should support a colon followed by an alpha',
@@ -57,24 +54,17 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
     }
   )
 
-  await t.test(
-    'should not support a colon followed by a digit',
-    async function () {
-      assert.equal(micromark(':9', options()), '<p>:9</p>')
-    }
-  )
+  await t.test('should support a colon followed by a digit', async function () {
+    assert.equal(micromark(':9', options()), '<p></p>')
+  })
 
   await t.test(
-    'should not support a colon followed by a dash',
+    'should not support a colon followed by a punctuation',
     async function () {
       assert.equal(micromark(':-', options()), '<p>:-</p>')
-    }
-  )
-
-  await t.test(
-    'should not support a colon followed by an underscore',
-    async function () {
       assert.equal(micromark(':_', options()), '<p>:_</p>')
+      assert.equal(micromark(':.', options()), '<p>:.</p>')
+      assert.equal(micromark(':\u2014', options()), '<p>:\u2014</p>') // Em dash
     }
   )
 
@@ -86,21 +76,18 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
     assert.equal(micromark(':a-b', options()), '<p></p>')
   })
 
-  await t.test(
-    'should *not* support a dash at the end of a name',
-    async function () {
-      assert.equal(micromark(':a-', options()), '<p>:a-</p>')
-    }
-  )
-
-  await t.test('should support an underscore in a name', async function () {
-    assert.equal(micromark(':a_b', options()), '<p></p>')
+  await t.test('should support unicode alphabets in name', async function () {
+    // Latin, Greek, Cyrillic respectively
+    assert.equal(micromark(':xγз', options()), '<p></p>')
   })
 
   await t.test(
-    'should *not* support an underscore at the end of a name',
+    'should *not* support punctuation at the end of a name',
     async function () {
+      assert.equal(micromark(':a-', options()), '<p>:a-</p>')
       assert.equal(micromark(':a_', options()), '<p>:a_</p>')
+      assert.equal(micromark(':a.', options()), '<p>:a.</p>')
+      assert.equal(micromark(':a\u2014', options()), '<p>:a\u2014</p>') // Em dash
     }
   )
 
@@ -411,16 +398,19 @@ test('micromark-extension-directive (syntax, leaf)', async function (t) {
   )
 
   await t.test(
-    'should not support two colons followed by a digit',
+    'should support two colons followed by a digit',
     async function () {
-      assert.equal(micromark('::9', options()), '<p>::9</p>')
+      assert.equal(micromark('::9', options()), '')
     }
   )
 
   await t.test(
-    'should not support two colons followed by a dash',
+    'should not support two colons followed by punctuation',
     async function () {
       assert.equal(micromark('::-', options()), '<p>::-</p>')
+      assert.equal(micromark('::_', options()), '<p>::_</p>')
+      assert.equal(micromark('::.', options()), '<p>::.</p>')
+      assert.equal(micromark('::\u2014', options()), '<p>::\u2014</p>') // Em dash
     }
   )
 
@@ -428,8 +418,17 @@ test('micromark-extension-directive (syntax, leaf)', async function (t) {
     assert.equal(micromark('::a9', options()), '')
   })
 
-  await t.test('should support a dash in a name', async function () {
+  await t.test('should support punctuation in a name', async function () {
     assert.equal(micromark('::a-b', options()), '')
+    assert.equal(micromark('::a-b', options()), '')
+    assert.equal(micromark('::a_b', options()), '')
+    assert.equal(micromark('::a.b', options()), '')
+    assert.equal(micromark('::a\u2014b', options()), '')
+  })
+
+  await t.test('should support unicode alphabets in name', async function () {
+    // Latin, Greek, Cyrillic respectively
+    assert.equal(micromark('::xγз', options()), '')
   })
 
   await t.test(
@@ -773,16 +772,19 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
   )
 
   await t.test(
-    'should not support three colons followed by a digit',
+    'should support three colons followed by a digit',
     async function () {
-      assert.equal(micromark(':::9', options()), '<p>:::9</p>')
+      assert.equal(micromark(':::9', options()), '')
     }
   )
 
   await t.test(
-    'should not support three colons followed by a dash',
+    'should not support three colons followed by punctuation',
     async function () {
       assert.equal(micromark(':::-', options()), '<p>:::-</p>')
+      assert.equal(micromark(':::_', options()), '<p>:::_</p>')
+      assert.equal(micromark(':::.', options()), '<p>:::.</p>')
+      assert.equal(micromark(':::\u2014', options()), '<p>:::\u2014</p>') // Em dash
     }
   )
 
@@ -790,8 +792,16 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
     assert.equal(micromark(':::a9', options()), '')
   })
 
-  await t.test('should support a dash in a name', async function () {
+  await t.test('should support punctuation in a name', async function () {
     assert.equal(micromark(':::a-b', options()), '')
+    assert.equal(micromark(':::a_b', options()), '')
+    assert.equal(micromark(':::a.b', options()), '')
+    assert.equal(micromark(':::a\u2014b', options()), '') // Em dash
+  })
+
+  await t.test('should support unicode alphabets in name', async function () {
+    // Latin, Greek, Cyrillic respectively
+    assert.equal(micromark(':::xγз', options()), '')
   })
 
   await t.test(

--- a/test/index.js
+++ b/test/index.js
@@ -100,10 +100,10 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
   })
 
   await t.test('should support math symbols in name', async function () {
-    assert.equal(micromark(':𝜋∈ℝ', options()), '<p></p>') // italic
-    assert.equal(micromark(':𝛑≈3.14', options()), '<p></p>') // bold
-    assert.equal(micromark(':𝝅∉ℚ', options()), '<p></p>') // bold italic
-    assert.equal(micromark(':𝞹≠3.14', options()), '<p></p>') // sans bold italic
+    assert.equal(micromark(':𝜋∈ℝ', options()), '<p></p>') // Italic
+    assert.equal(micromark(':𝛑≈3.14', options()), '<p></p>') // Bold
+    assert.equal(micromark(':𝝅∉ℚ', options()), '<p></p>') // Bold italic
+    assert.equal(micromark(':𝞹≠3.14', options()), '<p></p>') // Sans bold italic
   })
 
   await t.test(
@@ -112,7 +112,7 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
       assert.equal(micromark(':a-', options()), '<p>:a-</p>')
       assert.equal(micromark(':a_', options()), '<p>:a_</p>')
       assert.equal(micromark(':a.', options()), '<p>:a.</p>')
-      assert.equal(micromark(':a—', options()), '<p>:a—</p>') // em dash
+      assert.equal(micromark(':a—', options()), '<p>:a—</p>') // Em dash
     }
   )
 

--- a/test/index.js
+++ b/test/index.js
@@ -91,6 +91,18 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
     assert.equal(micromark(':â', options()), '<p></p>')
   })
 
+  await t.test('should support emojis in name', async function () {
+    assert.equal(micromark(':🌍', options()), '<p></p>')
+    assert.equal(micromark(':w🌍rld', options()), '<p></p>')
+  })
+
+  await t.test('should support math symbols in name', async function () {
+    assert.equal(micromark(':𝜋∈ℝ', options()), '<p></p>') // italic
+    assert.equal(micromark(':𝛑≈3.14', options()), '<p></p>') // bold
+    assert.equal(micromark(':𝝅∉ℚ', options()), '<p></p>') // bold italic
+    assert.equal(micromark(':𝞹≠3.14', options()), '<p></p>') // sans bold italic
+  })
+
   await t.test(
     'should *not* support punctuation at the end of a name',
     async function () {
@@ -449,6 +461,18 @@ test('micromark-extension-directive (syntax, leaf)', async function (t) {
   await t.test('should support unicode accents at the name end', async function () {
     // (Decomposed) Combining Circumflex Accent in Latin
     assert.equal(micromark('::â', options()), '')
+  })
+
+  await t.test('should support emojis in name', async function () {
+    assert.equal(micromark('::🌍', options()), '')
+    assert.equal(micromark('::w🌍rld', options()), '')
+  })
+
+  await t.test('should support math symbols in name', async function () {
+    assert.equal(micromark('::𝜋∈ℝ', options()), '') // italic
+    assert.equal(micromark('::𝛑≈3.14', options()), '') // bold
+    assert.equal(micromark('::𝝅∉ℚ', options()), '') // bold italic
+    assert.equal(micromark('::𝞹≠3.14', options()), '') // sans bold italic
   })
 
   await t.test(
@@ -832,6 +856,18 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
   await t.test('should support unicode accents at the name end', async function () {
     // (Decomposed) Combining Circumflex Accent in Latin
     assert.equal(micromark(':::â', options()), '')
+  })
+
+  await t.test('should support emojis in name', async function () {
+    assert.equal(micromark(':::🌍', options()), '')
+    assert.equal(micromark(':::w🌍rld', options()), '')
+  })
+
+  await t.test('should support math symbols in name', async function () {
+    assert.equal(micromark(':::𝜋∈ℝ', options()), '') // italic
+    assert.equal(micromark(':::𝛑≈3.14', options()), '') // bold
+    assert.equal(micromark(':::𝝅∉ℚ', options()), '') // bold italic
+    assert.equal(micromark(':::𝞹≠3.14', options()), '') // sans bold italic
   })
 
   await t.test(

--- a/test/index.js
+++ b/test/index.js
@@ -97,19 +97,19 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
   })
 
   await t.test('should support math symbols in name', async function () {
-    assert.equal(micromark(':𝜋∈ℝ', options()), '<p></p>') // italic
-    assert.equal(micromark(':𝛑≈3.14', options()), '<p></p>') // bold
-    assert.equal(micromark(':𝝅∉ℚ', options()), '<p></p>') // bold italic
-    assert.equal(micromark(':𝞹≠3.14', options()), '<p></p>') // sans bold italic
+    assert.equal(micromark(':𝜋∈ℝ', options()), '<p></p>') // Italic
+    assert.equal(micromark(':𝛑≈3.14', options()), '<p></p>') // Bold
+    assert.equal(micromark(':𝝅∉ℚ', options()), '<p></p>') // Bold italic
+    assert.equal(micromark(':𝞹≠3.14', options()), '<p></p>') // Sans bold italic
   })
 
   await t.test(
-    'should *not* support punctuation at the end of a name',
+    'should support punctuation at the end of a name',
     async function () {
-      assert.equal(micromark(':a-', options()), '<p>:a-</p>')
-      assert.equal(micromark(':a_', options()), '<p>:a_</p>')
-      assert.equal(micromark(':a.', options()), '<p>:a.</p>')
-      assert.equal(micromark(':a—', options()), '<p>:a—</p>') // em dash
+      assert.equal(micromark(':a-', options()), '<p></p>')
+      assert.equal(micromark(':a_', options()), '<p></p>')
+      assert.equal(micromark(':a.', options()), '<p></p>')
+      assert.equal(micromark(':a—', options()), '<p></p>') // Em dash
     }
   )
 

--- a/test/index.js
+++ b/test/index.js
@@ -100,19 +100,19 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
   })
 
   await t.test('should support math symbols in name', async function () {
-    assert.equal(micromark(':𝜋∈ℝ', options()), '<p></p>') // Italic
-    assert.equal(micromark(':𝛑≈3.14', options()), '<p></p>') // Bold
-    assert.equal(micromark(':𝝅∉ℚ', options()), '<p></p>') // Bold italic
-    assert.equal(micromark(':𝞹≠3.14', options()), '<p></p>') // Sans bold italic
+    assert.equal(micromark(':𝜋∈ℝ', options()), '<p></p>') // italic
+    assert.equal(micromark(':𝛑≈3.14', options()), '<p></p>') // bold
+    assert.equal(micromark(':𝝅∉ℚ', options()), '<p></p>') // bold italic
+    assert.equal(micromark(':𝞹≠3.14', options()), '<p></p>') // sans bold italic
   })
 
   await t.test(
-    'should support punctuation at the end of a name',
+    'should *not* support punctuation at the end of a name',
     async function () {
-      assert.equal(micromark(':a-', options()), '<p></p>')
-      assert.equal(micromark(':a_', options()), '<p></p>')
-      assert.equal(micromark(':a.', options()), '<p></p>')
-      assert.equal(micromark(':a—', options()), '<p></p>') // Em dash
+      assert.equal(micromark(':a-', options()), '<p>:a-</p>')
+      assert.equal(micromark(':a_', options()), '<p>:a_</p>')
+      assert.equal(micromark(':a.', options()), '<p>:a.</p>')
+      assert.equal(micromark(':a—', options()), '<p>:a—</p>') // em dash
     }
   )
 

--- a/test/index.js
+++ b/test/index.js
@@ -64,7 +64,7 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
       assert.equal(micromark(':-', options()), '<p>:-</p>')
       assert.equal(micromark(':_', options()), '<p>:_</p>')
       assert.equal(micromark(':.', options()), '<p>:.</p>')
-      assert.equal(micromark(':—', options()), '<p>:—</p>') // em dash
+      assert.equal(micromark(':—', options()), '<p>:—</p>') // Em dash
     }
   )
 
@@ -86,10 +86,13 @@ test('micromark-extension-directive (syntax, text)', async function (t) {
     assert.equal(micromark(':за́мок-чи-замо́к', options()), '<p></p>')
   })
 
-  await t.test('should support unicode accents at the name end', async function () {
-    // (Decomposed) Combining Circumflex Accent in Latin
-    assert.equal(micromark(':â', options()), '<p></p>')
-  })
+  await t.test(
+    'should support unicode accents at the name end',
+    async function () {
+      // (Decomposed) Combining Circumflex Accent in Latin
+      assert.equal(micromark(':â', options()), '<p></p>')
+    }
+  )
 
   await t.test('should support emojis in name', async function () {
     assert.equal(micromark(':🌍', options()), '<p></p>')
@@ -432,7 +435,7 @@ test('micromark-extension-directive (syntax, leaf)', async function (t) {
       assert.equal(micromark('::-', options()), '<p>::-</p>')
       assert.equal(micromark('::_', options()), '<p>::_</p>')
       assert.equal(micromark('::.', options()), '<p>::.</p>')
-      assert.equal(micromark('::—', options()), '<p>::—</p>') // em dash
+      assert.equal(micromark('::—', options()), '<p>::—</p>') // Em dash
     }
   )
 
@@ -458,10 +461,13 @@ test('micromark-extension-directive (syntax, leaf)', async function (t) {
     assert.equal(micromark('::за́мок-чи-замо́к', options()), '')
   })
 
-  await t.test('should support unicode accents at the name end', async function () {
-    // (Decomposed) Combining Circumflex Accent in Latin
-    assert.equal(micromark('::â', options()), '')
-  })
+  await t.test(
+    'should support unicode accents at the name end',
+    async function () {
+      // (Decomposed) Combining Circumflex Accent in Latin
+      assert.equal(micromark('::â', options()), '')
+    }
+  )
 
   await t.test('should support emojis in name', async function () {
     assert.equal(micromark('::🌍', options()), '')
@@ -469,10 +475,10 @@ test('micromark-extension-directive (syntax, leaf)', async function (t) {
   })
 
   await t.test('should support math symbols in name', async function () {
-    assert.equal(micromark('::𝜋∈ℝ', options()), '') // italic
-    assert.equal(micromark('::𝛑≈3.14', options()), '') // bold
-    assert.equal(micromark('::𝝅∉ℚ', options()), '') // bold italic
-    assert.equal(micromark('::𝞹≠3.14', options()), '') // sans bold italic
+    assert.equal(micromark('::𝜋∈ℝ', options()), '') // Italic
+    assert.equal(micromark('::𝛑≈3.14', options()), '') // Bold
+    assert.equal(micromark('::𝝅∉ℚ', options()), '') // Bold italic
+    assert.equal(micromark('::𝞹≠3.14', options()), '') // Sans bold italic
   })
 
   await t.test(
@@ -828,7 +834,7 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
       assert.equal(micromark(':::-', options()), '<p>:::-</p>')
       assert.equal(micromark(':::_', options()), '<p>:::_</p>')
       assert.equal(micromark(':::.', options()), '<p>:::.</p>')
-      assert.equal(micromark(':::—', options()), '<p>:::—</p>') // em dash
+      assert.equal(micromark(':::—', options()), '<p>:::—</p>') // Em dash
     }
   )
 
@@ -840,7 +846,7 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
     assert.equal(micromark(':::a-b', options()), '')
     assert.equal(micromark(':::a_b', options()), '')
     assert.equal(micromark(':::a.b', options()), '')
-    assert.equal(micromark(':::a—b', options()), '') // em dash
+    assert.equal(micromark(':::a—b', options()), '') // Em dash
   })
 
   await t.test('should support unicode alphabets in name', async function () {
@@ -853,10 +859,13 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
     assert.equal(micromark(':::за́мок-чи-замо́к', options()), '')
   })
 
-  await t.test('should support unicode accents at the name end', async function () {
-    // (Decomposed) Combining Circumflex Accent in Latin
-    assert.equal(micromark(':::â', options()), '')
-  })
+  await t.test(
+    'should support unicode accents at the name end',
+    async function () {
+      // (Decomposed) Combining Circumflex Accent in Latin
+      assert.equal(micromark(':::â', options()), '')
+    }
+  )
 
   await t.test('should support emojis in name', async function () {
     assert.equal(micromark(':::🌍', options()), '')
@@ -864,10 +873,10 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
   })
 
   await t.test('should support math symbols in name', async function () {
-    assert.equal(micromark(':::𝜋∈ℝ', options()), '') // italic
-    assert.equal(micromark(':::𝛑≈3.14', options()), '') // bold
-    assert.equal(micromark(':::𝝅∉ℚ', options()), '') // bold italic
-    assert.equal(micromark(':::𝞹≠3.14', options()), '') // sans bold italic
+    assert.equal(micromark(':::𝜋∈ℝ', options()), '') // Italic
+    assert.equal(micromark(':::𝛑≈3.14', options()), '') // Bold
+    assert.equal(micromark(':::𝝅∉ℚ', options()), '') // Bold italic
+    assert.equal(micromark(':::𝞹≠3.14', options()), '') // Sans bold italic
   })
 
   await t.test(


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Enables almost full Unicode support for directive names. This is tricky to test, I've added only Latin, Greek and Cyrillyc characters. Also, I have tested combining accent modifiers at the middle and at the end of directive name.

Attribute names are worth to look too but maybe in a separate PR.

The PR should be ready to review. Thank you!

Closes #23 

<!--do not edit: pr-->
