### PR TITLE
Add Pandoc like behavior for nested container directives

### DIFF
--- a/dev/lib/directive-container.js
+++ b/dev/lib/directive-container.js
@@ -36,6 +36,7 @@ function tokenizeDirectiveContainer(effects, ok, nok) {
       ? tail[2].sliceSerialize(tail[1], true).length
       : 0
   let sizeOpen = 0
+  let lvl = 0
   /** @type {Token} */
   let previous
 
@@ -224,7 +225,8 @@ function tokenizeDirectiveContainer(effects, ok, nok) {
         return closingSequence
       }
 
-      if (size < sizeOpen) return nok(code)
+      if (size === 0) return nok(code)
+
       effects.exit('directiveContainerSequence')
       return factorySpace(effects, closingSequenceEnd, types.whitespace)(code)
     }
@@ -232,10 +234,18 @@ function tokenizeDirectiveContainer(effects, ok, nok) {
     /** @type {State} */
     function closingSequenceEnd(code) {
       if (code === codes.eof || markdownLineEnding(code)) {
-        effects.exit('directiveContainerFence')
-        return ok(code)
+        if (lvl > 0) {
+          lvl--
+          return nok(code)
+        }
+
+        if (size >= sizeOpen) {
+          effects.exit('directiveContainerFence')
+          return ok(code)
+        }
       }
 
+      lvl++
       return nok(code)
     }
   }

--- a/readme.md
+++ b/readme.md
@@ -267,13 +267,21 @@ attributes: a *text* directive that only has a name, cannot be followed by a
 colon. So, `:red:` doesn’t work. Use either `:red[]` or `:red{}` instead.
 The reason for this is to allow GitHub emoji (gemoji) and directives to coexist.
 
-Containers can be nested by using more colons outside:
+Containers can be nested by using the same, more or less colons outside:
 
 ::::spoiler
 He dies.
 
-:::spoiler
+::::spoiler
 She is born.
+::::
+
+:::::spoiler
+It is resurrected.
+:::::
+
+:::spoiler
+We are redeemed.
 :::
 ::::
 

--- a/test/index.js
+++ b/test/index.js
@@ -943,6 +943,40 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
     }
   )
 
+  await t.test('should support nested directives', async function () {
+    assert.equal(micromark(':::a\n:::b\n:::\n:::\nc', options()), '<p>c</p>')
+  })
+
+  await t.test(
+    'should support nested directives with more colons',
+    async function () {
+      assert.equal(
+        micromark(':::a\n::::b\n::::\n:::\nc', options()),
+        '<p>c</p>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support nested directives with less colons',
+    async function () {
+      assert.equal(
+        micromark('::::a\n:::b\n:::\n::::\nc', options()),
+        '<p>c</p>'
+      )
+    }
+  )
+
+  await t.test(
+    'should support closing nested directives with more colons than the opening',
+    async function () {
+      assert.equal(
+        micromark('::::a\n:::b\n::::\n::::\nc', options()),
+        '<p>c</p>'
+      )
+    }
+  )
+
   await t.test(
     'should close w/ a closing fence followed by white space',
     async function () {


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

I one again try to push [this](https://github.com/micromark/micromark-extension-directive/issues/8) discussion. I want to switch from pandoc to remark and this feature is one of the essential "missing" features. I know the common mark proposal is different, but it is so inconvenient. And I know you suggested to add it behind a flag, but as it is backwards compatible I think it can be the default.

[Try pandoc](https://pandoc.org/try/?params=%7B%22text%22%3A%22%3A%3A%3A%3Aspoiler%5CnHe+dies.%5Cn%5Cn%3A%3A%3A%3Aspoiler%5CnShe+is+born.%5Cn%3A%3A%3A%3A%5Cn%5Cn%3A%3A%3A%3A%3Aspoiler%5CnIt+is+resurrected.%5Cn%3A%3A%3A%3A%3A%5Cn%5Cn%3A%3A%3Aspoiler%5CnWe+are+redeemed.%5Cn%3A%3A%3A%5Cn%3A%3A%3A%3A%22%2C%22to%22%3A%22html5%22%2C%22from%22%3A%22markdown%22%2C%22standalone%22%3Afalse%2C%22embed-resources%22%3Afalse%2C%22table-of-contents%22%3Afalse%2C%22number-sections%22%3Afalse%2C%22citeproc%22%3Afalse%2C%22html-math-method%22%3A%22plain%22%2C%22wrap%22%3A%22auto%22%2C%22highlight-style%22%3Anull%2C%22files%22%3A%7B%7D%2C%22template%22%3Anull%7D)

<!--do not edit: pr-->
