### PR TITLE
Avoid exception when unclosed directive container is found within another container and chunkDocument is empty (fixes #16, fixes micromark/micromark#173).

### DIFF
--- a/dev/lib/directive-container.js
+++ b/dev/lib/directive-container.js
@@ -179,6 +179,16 @@ function tokenizeDirectiveContainer(effects, ok, nok) {
 
   /** @type {State} */
   function lineAfter(code) {
+    const now = self.now()
+    if (
+      previous.start._index === now._index &&
+      previous.start._bufferIndex === now._bufferIndex
+    ) {
+      // Used to avoid "expected non-empty token" in cases where
+      // an un-closed directive is found within a container
+      return nok(code)
+    }
+
     const t = effects.exit(types.chunkDocument)
     self.parser.lazy[t.start.line] = false
     return after(code)

--- a/test/index.js
+++ b/test/index.js
@@ -1211,6 +1211,26 @@ test('micromark-extension-directive (syntax, container)', async function (t) {
       '<blockquote><a></a>\n</blockquote>\n<p>:::</p>'
     )
   })
+
+  await t.test(
+    'should support being inside blockquote without close',
+    async function () {
+      assert.equal(
+        micromark('> :::directive\n>\n', options()),
+        '<blockquote>\n<p>:::directive</p>\n</blockquote>\n'
+      )
+    }
+  )
+
+  await t.test(
+    'should support being inside list item without close',
+    async function () {
+      assert.equal(
+        micromark('* text\n   :::note\n\ntext', options()),
+        '<ul>\n<li>text:::note</li>\n</ul>\n<p>text</p>'
+      )
+    }
+  )
 })
 
 test('micromark-extension-directive (compile)', async function (t) {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Avoid exception when unclosed directive container is found within another container and chunkDocument is empty (fixes #16, fixes micromark/micromark#173).

I tried for a while to parse the scenario successfully, but couldn't find a way to avoid creating an empty container that didn't break one of the existing "lazy" tests. As it is already an edge-case scenario, giving up like this seems okay to me - definitely better than crashing callers. :)

<!--do not edit: pr-->
